### PR TITLE
Update pgsql-client.sh

### DIFF
--- a/pgsql-client.sh
+++ b/pgsql-client.sh
@@ -2,6 +2,6 @@
 touch /etc/apt/sources.list.d/pgdg.list
 echo "deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-apt update
-apt install -y postgresql-client
+apt-get update -y
+apt-get install -y postgresql-client
 source ~/.bashrc


### PR DESCRIPTION
With Debian Jessie it is better use apt-get for prevent "WARNING: apt does not have a stable CLI interface yet. Use with caution in scripts."